### PR TITLE
Fix rollup bundling and package.json entrypoints

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,5 +8,8 @@
     ],
     "react"
   ],
-  "plugins": ["transform-class-properties"]
+  "plugins": [
+    "external-helpers",
+    "transform-class-properties"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,10 @@
   "author": "Imran Sulemanji <imran.sulemanji@gmail.com>",
   "license": "MIT",
   "private": false,
-  "dependencies": {
+  "dependencies": {},
+  "peerDependencies": {
     "date-fns": "^1.29.0",
-    "prop-types": "^15.6.0"
-  },
-  "peerDependecies": {
+    "prop-types": "^15.6.0",
     "react": "^16.2.0"
   },
   "devDependencies": {
@@ -30,12 +29,19 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "date-fns": "^1.29.0",
     "flow-bin": "^0.60.1",
+    "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "rollup": "^0.54.0",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.2.6",
+    "rollup-plugin-es3": "^1.1.0",
+    "rollup-plugin-filesize": "^1.5.0",
+    "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-uglify-es": "^0.0.1",
     "styled-components": "^2.2.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "react-calendar-listview",
   "version": "0.1.0",
   "description": "Primitives for building calendars in React",
-  "main": "dist/react-calendar.umd.js",
-  "jsnext:main": "src/index.js",
-  "module": "src/index.js",
+  "main": "dist/react-calendar.cjs.js",
+  "jsnext:main": "dist/react-calendar.es.js",
+  "module": "dist/react-calendar.es.js",
   "repository": "https://github.com/imranolas/react-calendar.git",
   "bugs": {
     "url": "https://github.com/imranolas/react-calendar/issues"
@@ -13,7 +13,6 @@
   "author": "Imran Sulemanji <imran.sulemanji@gmail.com>",
   "license": "MIT",
   "private": false,
-  "dependencies": {},
   "peerDependencies": {
     "date-fns": "^1.29.0",
     "prop-types": "^15.6.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,32 +46,40 @@ const prodPlugins = [
 
 const name = 'ReactCalendar';
 
-const withBase = config => ({
-  ...config,
-  input: 'src/index.js',
-  external,
-});
-
-const umdBase = {
-  name,
-  exports: 'named',
-  globals
+const externalFn = id => {
+  const [first] = id.split('/');
+  return external.includes(first);
 };
+
+const withBase = config => ({
+  external: externalFn,
+  ...config,
+  output: config.output.map(x => ({
+    ...x,
+    name,
+    globals,
+    exports: 'named'
+  })),
+  input: 'src/index.js'
+});
 
 export default [
   {
     output: [{
       file: './dist/react-calendar.min.js',
-      format: 'umd',
-      ...umdBase
+      format: 'umd'
     }],
+    external, // For UMDs, nested imports must be bundled
     plugins: prodPlugins
   }, {
     output: [{
       file: './dist/react-calendar.js',
       format: 'umd',
-      ...umdBase
-    }, {
+    }],
+    external, // For UMDs, nested imports must be bundled
+    plugins
+  }, {
+    output: [{
       file: './dist/react-calendar.es.js',
       format: 'es'
     }, {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,28 +1,83 @@
 import babel from 'rollup-plugin-babel';
-import resolve from 'rollup-plugin-node-resolve';
-import commonJs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import flow from 'rollup-plugin-flow';
+import uglify from 'rollup-plugin-uglify-es';
+import es3 from 'rollup-plugin-es3';
+import filesize from 'rollup-plugin-filesize';
 
-const globals = {};
+const { peerDependencies } = require('./package.json');
+const external = Object.keys(peerDependencies || {});
 
-export default {
+// https://github.com/developit/microbundle/blob/master/src/index.js#L150
+const globals = external.reduce( (globals, name) => {
+  // valid JS identifiers are usually library globals:
+  if (name.match(/^[a-z_$][a-z0-9_$]*$/)) {
+    globals[name] = name;
+  }
+  return globals;
+}, {});
+
+const plugins = [
+  commonjs({
+    include: 'node_modules/**'
+  }),
+  nodeResolve({
+    browser: true,
+    module: true,
+    jsnext: true
+  }),
+  babel({
+    exclude: 'node_modules/**',
+    externalHelpers: true
+  }),
+  flow({
+    all: true,
+    pretty: true
+  }),
+  es3()
+];
+
+const prodPlugins = [
+  ...plugins,
+  uglify(),
+  filesize()
+];
+
+const name = 'ReactCalendar';
+
+const withBase = config => ({
+  ...config,
   input: 'src/index.js',
-  output: {
-    file: './dist/react-calendar.umd.js',
-    format: 'umd'
-  },
-  name: 'reactCalendar',
-  exports: 'named',
-  globals,
+  external,
+});
 
-  sourcemap: true,
-  plugins: [
-    resolve({
-      browser: true
-    }),
-    babel({
-      exclude: 'node_modules/**' // only transpile our source code
-    }),
-    commonJs({})
-  ],
-  external: ['react']
+const umdBase = {
+  name,
+  exports: 'named',
+  globals
 };
+
+export default [
+  {
+    output: [{
+      file: './dist/react-calendar.min.js',
+      format: 'umd',
+      ...umdBase
+    }],
+    plugins: prodPlugins
+  }, {
+    output: [{
+      file: './dist/react-calendar.js',
+      format: 'umd',
+      ...umdBase
+    }, {
+      file: './dist/react-calendar.es.js',
+      format: 'es'
+    }, {
+      file: './dist/react-calendar.cjs.js',
+      format: 'cjs'
+    }],
+    plugins
+  }
+].map(withBase);

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,6 +261,12 @@ alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
 
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  dependencies:
+    string-width "^2.0.0"
+
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -1335,7 +1341,7 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.18.0:
+babylon@^6.15.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -1415,6 +1421,18 @@ boom@5.x.x:
 bowser@^1.0.0, bowser@^1.7.3:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.8.1.tgz#49785777e7302febadb1a5b71d9a646520ed310d"
+
+boxen@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1546,7 +1564,7 @@ camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
-camelcase@^4.1.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
@@ -1596,7 +1614,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.3.0:
+chalk@^2.0.1, chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -1635,6 +1653,10 @@ clap@^1.0.9:
 classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1702,7 +1724,7 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@~1.1.2:
+colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -1715,6 +1737,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@^2.11.0, commander@^2.9.0:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
+commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 common-tags@^1.4.0:
   version "1.5.1"
@@ -1993,6 +2021,12 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-assign@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-2.0.0.tgz#ebe06b1f07f08dae597620e3dd1622f371a1c572"
+  dependencies:
+    is-obj "^1.0.0"
+
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -2076,6 +2110,10 @@ dot-prop@^4.1.0:
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:
     is-obj "^1.0.0"
+
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -2410,6 +2448,10 @@ filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
+filesize@^3.5.6:
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -2453,6 +2495,13 @@ flatten@^1.0.2:
 flow-bin@^0.60.1:
   version "0.60.1"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.60.1.tgz#0f4fa7b49be2a916f18cd946fc4a51e32ffe4b48"
+
+flow-remove-types@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-1.2.3.tgz#6131aefc7da43364bb8b479758c9dec7735d1a18"
+  dependencies:
+    babylon "^6.15.0"
+    vlq "^0.2.1"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -2640,6 +2689,16 @@ globals@^9.18.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+gzip-size@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
+  dependencies:
+    duplexer "^0.1.1"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -4544,6 +4603,29 @@ rollup-plugin-commonjs@^8.2.6:
     resolve "^1.4.0"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-es3@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-es3/-/rollup-plugin-es3-1.1.0.tgz#f866f91b4db839e5b475d8e4a7b9d4c77ecade14"
+  dependencies:
+    magic-string "^0.22.4"
+
+rollup-plugin-filesize@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-1.5.0.tgz#bb5841242d88be57f231c9e8a3a541925392178b"
+  dependencies:
+    boxen "^1.1.0"
+    colors "^1.1.2"
+    deep-assign "^2.0.0"
+    filesize "^3.5.6"
+    gzip-size "^3.0.0"
+
+rollup-plugin-flow@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-flow/-/rollup-plugin-flow-1.1.1.tgz#6ce568f1dd559666b77ab76b4bae251407528db6"
+  dependencies:
+    flow-remove-types "^1.1.0"
+    rollup-pluginutils "^1.5.1"
+
 rollup-plugin-node-resolve@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
@@ -4553,7 +4635,13 @@ rollup-plugin-node-resolve@^3.0.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
-rollup-pluginutils@^1.5.0:
+rollup-plugin-uglify-es@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify-es/-/rollup-plugin-uglify-es-0.0.1.tgz#e45644f2b685a59abdb9363407207a03a7b5a9b7"
+  dependencies:
+    uglify-es "3.0.3"
+
+rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:
@@ -4566,6 +4654,10 @@ rollup-pluginutils@^2.0.1:
   dependencies:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
+
+rollup@^0.54.0:
+  version "0.54.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.54.0.tgz#0641b8154ba02706464285d2ead924c486b48ba9"
 
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -4786,7 +4878,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -4929,6 +5021,12 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  dependencies:
+    execa "^0.7.0"
+
 through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -4985,6 +5083,15 @@ type-is@~1.6.15:
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
+uglify-es@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.0.3.tgz#63cc84aa9468b34973a4887787c64c01a8a87576"
+  dependencies:
+    commander "~2.9.0"
+    source-map "~0.5.1"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
 
 uglify-js@^2.8.29:
   version "2.8.29"
@@ -5204,6 +5311,12 @@ wide-align@^1.1.0:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
+
+widest-line@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.0.tgz#0142a4e8a243f8882c0233aa0e0281aa76152273"
+  dependencies:
+    string-width "^2.1.1"
 
 window-size@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- Improve bundling
- Create ES/CJS bundles
- Split UMD into minified and non-minified
- Output filesize
- Externalise date-fns for ES/CJS
- Change entrypoints pointing to src (ES & Flow (!)) to bundles